### PR TITLE
Clean up some code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Metadata, binaries, and gcov files
+*.gcda
+*.gcno
+*.gcov
+*.app
+*.plist
+*.dSYM
+
+# Generated files from Collatz
+projects/collatz/RunCollatz
+projects/collatz/RunCollatz.tmp
+projects/collatz/TestCollatz
+projects/collatz/TestCollatz.tmp
+
+# Generated documentation
+html
+latex
+doxygen_sqlite3.db

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "projects/collatz/collatz-tests"]
+	path = projects/collatz/collatz-tests
+	url = git@github.com:cs371p-fall-2016/collatz-tests.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "projects/collatz/collatz-tests"]
 	path = projects/collatz/collatz-tests
-	url = git@github.com:cs371p-fall-2016/collatz-tests.git
+	url = https://github.com/cs371p-fall-2016/collatz-tests.git

--- a/examples/makefile
+++ b/examples/makefile
@@ -51,6 +51,8 @@ else                                                                 # UTCS
     CLANG-FORMAT := clang-format-3.8
 endif
 
+.DEFAULT_GOAL := test
+
 %.app: %.c++
 	$(CXX) $(CXXFLAGS) $< -o $@
 ifneq ($(shell uname -p), unknown)                       # Docker

--- a/exercises/makefile
+++ b/exercises/makefile
@@ -50,6 +50,8 @@ else                                                                 # UTCS
     CLANG-FORMAT := clang-format-3.8
 endif
 
+.DEFAULT_GOAL := test
+
 %.app: %.c++
 	$(CXX) $(CXXFLAGS) $(GCOVFLAGS) $< -o $@ $(LDFLAGS)
 ifneq ($(shell uname -p), unknown)                       # Docker

--- a/makefile
+++ b/makefile
@@ -48,6 +48,8 @@ else                                                                 # UTCS
     CLANG-FORMAT := clang-format-3.8
 endif
 
+.DEFAULT_GOAL := test
+
 clean:
 	cd examples; make clean
 	@echo
@@ -79,13 +81,11 @@ init:
 	git push -u origin master
 
 pull:
-	make clean
 	@echo
 	git pull
 	git status
 
 push:
-	make clean
 	@echo
 	git add .travis.yml
 	git add Dockerfile
@@ -98,7 +98,6 @@ push:
 	git status
 
 status:
-	make clean
 	@echo
 	git branch
 	git remote -v
@@ -132,7 +131,6 @@ sync:
     ../../projects/c++/collatz/ projects/collatz
 
 test:
-	make clean
 	@echo
 	cd examples; make test
 	@echo

--- a/projects/collatz/TestCollatz.c++
+++ b/projects/collatz/TestCollatz.c++
@@ -13,7 +13,6 @@
 #include <iostream> // cout, endl
 #include <sstream>  // istringtstream, ostringstream
 #include <string>   // string
-#include <utility>  // pair
 
 #include "gtest/gtest.h"
 

--- a/projects/collatz/makefile
+++ b/projects/collatz/makefile
@@ -65,8 +65,7 @@ else                                                                 # UTCS
     CLANG-FORMAT := clang-format-3.8
 endif
 
-collatz-tests:
-	git clone https://github.com/cs371p-fall-2016/collatz-tests.git
+.DEFAULT_GOAL := test
 
 html: Doxyfile Collatz.h Collatz.c++ RunCollatz.c++ TestCollatz.c++
 	doxygen Doxyfile
@@ -148,10 +147,9 @@ scrub:
 	rm -rf latex
 
 status:
-	make clean
 	@echo
 	git branch
 	git remote -v
 	git status
 
-test: html Collatz.log RunCollatz.tmp TestCollatz.tmp collatz-tests check
+test: html Collatz.log RunCollatz.tmp TestCollatz.tmp check


### PR DESCRIPTION
* Added a `.gitignore`, which makes the git-related make targets more manageable.
* Added `collatz-tests` as a proper submodule.
* Added `.DEFAULT_GOAL = test` in the relevant makefiles so that `make` with no arguments runs tests instead of cleaning everything out.
* Removed an unused `#include` in `TestCollatz.c++`